### PR TITLE
chore: run lerna bootstrap in postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "tty.js": "^0.2.15"
     },
     "scripts": {
+        "postinstall": "lerna bootstrap",
         "start:app": "cd packages/klingon-app/ && npm start",
         "start:server": "cd packages/klingon-server/ && npm start"
     }


### PR DESCRIPTION
This small patch makes sure the server/app run after doing a top-level `npm install` 